### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,7 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to root_path
+      redirect_to item_path(@item.id)
     else
       render :new
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,12 +4,10 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.includes(:user).order(created_at: :DESC)
-    @purchases = Purchase.all
   end
 
   def show
     @item = Item.includes(:user).find(params[:id])
-    @purchases = Purchase.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,13 +3,12 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @items = Item.includes(:user).order(created_at: "DESC")
+    @items = Item.includes(:user).order(created_at: :DESC)
     @purchases = Purchase.all
   end
 
   def show
-    @items = Item.includes(:user)
-    @item = @items.find(params[:id])
+    @item = Item.includes(:user).find(params[:id])
     @purchases = Purchase.all
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   # ログイン確認をする
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.includes(:user).order(created_at: "DESC")
@@ -8,6 +8,9 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @items = Item.includes(:user)
+    @item = @items.find(params[:id])
+    @purchases = Purchase.all
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,4 +21,25 @@ class Item < ApplicationRecord
     validates :from,      numericality: { other_than: 0, message: "can't be blank" } # 発送元
     validates :period,    numericality: { other_than: 0, message: "can't be blank" } # 出荷日数
   end
+
+  # 商品が販売中かどうか判定するメソッド
+  # 商品が販売中であればtrue, 購入済みであればfalseを返す
+  def on_sale
+    if Purchase.where(item_id: self.id).empty?
+      return true
+    else
+      return false
+    end
+  end
+
+  # 引数としてユーザーを渡すと、その商品の出品者かどうか判定するメソッド
+  # 出品者であればtrue,出品者でなければfalseを返す
+  def owner(target)
+    if self.user_id == target.id
+      return true
+    else
+      return false
+    end
+  end
+
 end

--- a/app/views/items/_item_list.html.erb
+++ b/app/views/items/_item_list.html.erb
@@ -4,7 +4,7 @@
     <div class='item-img-content'>
       <%= image_tag item.image, class: "item-img" %>
       <%# *****商品が売れていればsold outの表示をする***** %>
-      <% if @purchases.exists?(item_id: item.id) %>
+      <% if !item.on_sale %>
         <div class='sold-out'>
           <span>Sold Out!!</span>
         </div>

--- a/app/views/items/_item_list.html.erb
+++ b/app/views/items/_item_list.html.erb
@@ -1,14 +1,14 @@
 <li class='list'>
-  <%= link_to "#" do %>
+  <%= link_to item_path(item.id) do %>
     <%# ********** 商品画像 ********** %>
     <div class='item-img-content'>
-      <%= image_tag item.image.variant(resize:'281x281'), class: "item-img" %>
+      <%= image_tag item.image, class: "item-img" %>
       <%# *****商品が売れていればsold outの表示をする***** %>
-        <% if @purchases.exists?(item_id: item.id) %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-        <% end %>
+      <% if @purchases.exists?(item_id: item.id) %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <%# ********** 商品情報 ********** %>
     <div class='item-info'>
@@ -16,7 +16,7 @@
         <%= item.name %>
       </h3>
       <div class='item-price'>
-        <span><%= item.price %>円<br>(税込み)</span>
+        <span><%= item.price.to_s(:delimited) %>円<br>(税込み)</span>
         <div class='star-btn'>
           <%= image_tag "star.png", class:"star-icon" %>
           <span class='star-count'>0</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,19 +4,21 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
+      <% if @purchases.exists?(item_id: @item.id) %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price.to_s(:delimited) %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,14 +26,18 @@
     </div>
 
     <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% if user_signed_in? %>
+      <% if @item.user_id == current_user.id %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% end %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <% if @purchases.where(item_id: @item.id).empty? && @item.user_id != current_user.id %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
     <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
@@ -42,27 +48,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= Category.find(@item.category).name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= Condition.find(@item.condition).name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= Charge.find(@item.charge).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= Prefecture.find(@item.from).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= Period.find(@item.period).name %></td>
         </tr>
       </tbody>
     </table>
@@ -94,14 +100,16 @@
     </form>
   </div>
   <div class="links">
-    <a href="#" class="change-item-btn">
-      ＜ 前の商品
-    </a>
-    <a href="#" class="change-item-btn">
-      後ろの商品 ＞
-    </a>
+    <% if @item.id < @items.length %>
+      <%= link_to "＜ 前の商品", item_path(@item.id + 1), class:"change-item-btn" %>
+    <% end %>
+    <% if @item.id > 1 %>
+      <%= link_to "後ろの商品 ＞", item_path(@item.id - 1), class:"change-item-btn" %>
+    <% end %>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+
+  <%= link_to "#{Category.find(@item.category).name}をもっと見る", "/#", class:'another-item' %>
+
 </div>
 
-<%= render "shared/footer" %>
+<%# render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,18 +26,18 @@
     </div>
 
     <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-    <% if user_signed_in? %>
-      <% if @item.user_id == current_user.id %>
-        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-        <p class='or-text'>or</p>
-        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-      <% end %>
-      <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <% if @purchases.where(item_id: @item.id).empty? && @item.user_id != current_user.id %>
-        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-      <% end %>
-      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <%# 「ログイン中」かつ「出品者がログイン中のユーザーと同じである」 %>
+    <% if user_signed_in? && @item.owner(current_user) %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% end %>
+    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <%# 「ログイン中」かつ「商品が販売中である」かつ「出品者がログイン中のユーザーではない」 %>
+    <% if user_signed_in? && @item.on_sale && !@item.owner(current_user) %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
 
     <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
@@ -100,10 +100,10 @@
     </form>
   </div>
   <div class="links">
-    <% if @item.id < @items.length %>
+    <% if Item.exists?(id: @item.id + 1) %>
       <%= link_to "＜ 前の商品", item_path(@item.id + 1), class:"change-item-btn" %>
     <% end %>
-    <% if @item.id > 1 %>
+    <% if @item.id - 1 > 0 %>
       <%= link_to "後ろの商品 ＞", item_path(@item.id - 1), class:"change-item-btn" %>
     <% end %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,7 +9,7 @@
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <% if @purchases.exists?(item_id: @item.id) %>
+      <% if !@item.on_sale %>
         <div class='sold-out'>
           <span>Sold Out!!</span>
         </div>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     price { rand(300..9_999_999) }
     category { rand(1..10) }
     condition { rand(1..6) }
-    charge { rand(1..4) }
+    charge { rand(1..2) }
     from { rand(1..47) }
     period { rand(1..3) }
     image { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/files/test.png'), 'image/png') }


### PR DESCRIPTION
# 商品詳細表示機能の実装
 商品詳細表示機能を実装しました。
- 一つの商品だけの写真・価格・発送の情報等詳細情報を載せるページを作成
- ログアウト状態でも商品詳細ページを閲覧できる仕様
- 出品者だけに商品の編集・削除のリンクを表示する仕様
- 出品者以外のログインユーザーのみ商品購入のリンクを表示する仕様
- 商品出品時に商品詳細ページに遷移する仕様

# Why
商品の詳細を表示するページを作成するため。


## 動作イメージ
https://photos.app.goo.gl/7RAc1GbjoB8m2WRe7
