### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,12 @@
  *= require_tree .
  *= require_self
  */
+.flash {
+  width: 100%;
+  height: 2em;
+  color: white;
+  background-color: orange;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,15 @@
 class ItemsController < ApplicationController
   # ログイン確認をする
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :confirm_user, only: [:edit, :update, :destroy]
+
+  def confirm_user
+    @item = Item.find_by(params[:id])
+    if @item.user_id != current_user.id
+      flash[:notice] = "権限がありません"
+      redirect_to root_path
+    end
+  end
 
   def index
     @items = Item.includes(:user).order(created_at: :DESC)
@@ -24,9 +33,16 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @item = Item.find(params[:id])
   end
 
   def update
+    item = Item.find(params[:id])
+    if item.update(tweet_params)
+      redirect_to item_path(item.id)
+    else
+      render :edit
+    end
   end
 
   def destroy

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   # ログイン確認をする
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit]
+  before_action :set_item, only: [:show, :edit, :update]
   before_action :confirm_user, only: [:edit, :update, :destroy]
 
   def confirm_user

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,10 +5,10 @@ class ItemsController < ApplicationController
 
   def confirm_user
     @item = Item.find(params[:id])
-    if @item.user_id != current_user.id
-      flash[:notice] = "権限がありません"
-      redirect_to root_path
-    end
+    return unless @item.user_id != current_user.id
+
+    flash[:notice] = "権限がありません"
+    redirect_to root_path
   end
 
   def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,7 @@ class ItemsController < ApplicationController
   before_action :confirm_user, only: [:edit, :update, :destroy]
 
   def confirm_user
-    @item = Item.find_by(params[:id])
+    @item = Item.find(params[:id])
     if @item.user_id != current_user.id
       flash[:notice] = "権限がありません"
       redirect_to root_path
@@ -26,6 +26,7 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
+      flash[:notice] = "商品を出品しました"
       redirect_to item_path(@item.id)
     else
       render :new
@@ -38,7 +39,8 @@ class ItemsController < ApplicationController
 
   def update
     @item = Item.find(params[:id])
-    if @item.update(tweet_params)
+    if @item.update(item_params)
+      flash[:notice] = "商品の情報を更新しました"
       redirect_to item_path(@item.id)
     else
       render :edit

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   # ログイン確認をする
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:show, :edit]
   before_action :confirm_user, only: [:edit, :update, :destroy]
 
   def confirm_user
@@ -11,12 +12,15 @@ class ItemsController < ApplicationController
     redirect_to root_path
   end
 
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
   def index
     @items = Item.includes(:user).order(created_at: :DESC)
   end
 
   def show
-    @item = Item.includes(:user).find(params[:id])
   end
 
   def new
@@ -34,11 +38,9 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       flash[:notice] = "商品の情報を更新しました"
       redirect_to item_path(@item.id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,9 +37,9 @@ class ItemsController < ApplicationController
   end
 
   def update
-    item = Item.find(params[:id])
-    if item.update(tweet_params)
-      redirect_to item_path(item.id)
+    @item = Item.find(params[:id])
+    if @item.update(tweet_params)
+      redirect_to item_path(@item.id)
     else
       render :edit
     end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -25,21 +25,16 @@ class Item < ApplicationRecord
   # 商品が販売中かどうか判定するメソッド
   # 商品が販売中であればtrue, 購入済みであればfalseを返す
   def on_sale
-    if Purchase.where(item_id: self.id).empty?
-      return true
-    else
-      return false
-    end
+    return true if Purchase.where(item_id: id).empty?
+
+    false
   end
 
   # 引数としてユーザーを渡すと、その商品の出品者かどうか判定するメソッド
   # 出品者であればtrue,出品者でなければfalseを返す
   def owner(target)
-    if self.user_id == target.id
-      return true
-    else
-      return false
-    end
-  end
+    return true if user_id == target.id
 
+    false
+  end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :note, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category, Category.all, :id, :name, { include_blank: "---" }, {class:"select-box", id:"item-category", required: true}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition, Condition.all, :id, :name, { include_blank: "---" }, {class:"select-box", id:"item-sales-status", required: true }) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:charge, Charge.all, :id, :name, { include_blank: "---" }, { class:"select-box", id:"item-shipping-fee-status", required: true }) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:from, Prefecture.all, :id, :name, { include_blank: "---" }, { class:"select-box", id:"item-prefecture", required: true }) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:period, Period.all, :id, :name, { include_blank: "---" }, { class:"select-box", id:"item-scheduled-delivery", required: true }) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300", required: true %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,6 +1,3 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
-
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
@@ -9,9 +6,8 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# エラーメッセージ %>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -27,6 +23,7 @@ app/assets/stylesheets/items/new.css %>
       </div>
     </div>
     <%# /出品画像 %>
+
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -7,9 +7,8 @@
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# エラーメッセージ %>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
     <div class="img-upload">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -5,7 +5,7 @@
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, url: items_path(@item), local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
@@ -50,12 +50,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category, Category.all, :id, :name, {include_blank: "---"}, {class:"select-box", id:"item-category", required: true}) %>
+        <%= f.collection_select(:category, Category.all, :id, :name, { include_blank: "---" }, {class:"select-box", id:"item-category", required: true }) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:condition, Condition.all, :id, :name, {include_blank: "---"}, {class:"select-box", id:"item-sales-status", required: true}) %>
+        <%= f.collection_select(:condition, Condition.all, :id, :name, { include_blank: "---" }, {class:"select-box", id:"item-sales-status", required: true }) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,17 +71,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:charge, Charge.all, :id, :name, {include_blank: "---"}, {class:"select-box", id:"item-shipping-fee-status", required: true}) %>
+        <%= f.collection_select(:charge, Charge.all, :id, :name, { include_blank: "---" }, {class:"select-box", id:"item-shipping-fee-status", required: true }) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:from, Prefecture.all, :id, :name, {include_blank: "---"}, {class:"select-box", id:"item-prefecture", required: true}) %>
+        <%= f.collection_select(:from, Prefecture.all, :id, :name, { include_blank: "---" }, {class:"select-box", id:"item-prefecture", required: true }) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:period, Period.all, :id, :name, {include_blank: "---"}, {class:"select-box", id:"item-scheduled-delivery", required: true}) %>
+        <%= f.collection_select(:period, Period.all, :id, :name, { include_blank: "---" }, {class:"select-box", id:"item-scheduled-delivery", required: true }) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,13 +8,12 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
+      <%# 売り切れの場合の表示 %>
       <% if !@item.on_sale %>
         <div class='sold-out'>
           <span>Sold Out!!</span>
         </div>
       <% end %>
-      <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -25,21 +24,16 @@
       </span>
     </div>
 
-    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-    <%# 「ログイン中」かつ「出品者がログイン中のユーザーと同じである」 %>
+    <%# ログインユーザーが出品者の場合、編集・削除リンクを表示 %>
     <% if user_signed_in? && @item.owner(current_user) %>
       <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% end %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%# 「ログイン中」かつ「商品が販売中である」かつ「出品者がログイン中のユーザーではない」 %>
+    <%# 商品が販売中の場合、ログインユーザーに購入リンクを表示する %>
     <% if user_signed_in? && @item.on_sale && !@item.owner(current_user) %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
-      <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -111,5 +105,4 @@
   <%= link_to "#{Category.find(@item.category).name}をもっと見る", "/#", class:'another-item' %>
 
 </div>
-
-<%# render "shared/footer" %>
+<%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
     <%# 「ログイン中」かつ「出品者がログイン中のユーザーと同じである」 %>
     <% if user_signed_in? && @item.owner(current_user) %>
-      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,11 @@
   </head>
 
   <body>
+    <% if flash[:notice] %>
+      <div class="flash">  
+        <p><%= flash[:notice] %></p>
+      </div>
+    <% end %>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
# What
商品編集機能を実装しました。
- 商品情報（商品画像・商品名・商品の状態など）を変更できる機能
- 何も編集せずに更新しても、商品の画像のない商品にはならない設定
- 出品者だけが編集ページに遷移できる設定
- 出品時とほぼ同じUIで編集できる機能
- 商品編集画面を開いた際に、商品名やカテゴリー情報などのすでに登録されている商品情報が表示される機能
- バリデーションによる編集内容へのエラーメッセージを表示

# Why
出品した商品を出品者が編集できるようにするため。


## 動作イメージ
https://photos.app.goo.gl/Seq4XCj1pKo13xK99